### PR TITLE
minor changes on doc format based on markdown lint

### DIFF
--- a/docusaurus/docs/api/factory.md
+++ b/docusaurus/docs/api/factory.md
@@ -7,6 +7,7 @@ sidebar_label: Factory
 Backends, which work as queue factories, have the following operations:
 
 ## `MQ`: Factory initialization
+
 ```javascript
 var QM = require ('keuss/backends/<backend>');
 
@@ -16,6 +17,7 @@ MQ (opts, (err, factory) => {
 ```
 
 where `opts` is an object containing initialization options. Common properties to all backends are:
+
 * `name`: Name for the factory, defaults to 'N'.
 * `stats`:
   * `provider`: stats backend to use, as result of `require ('keuss/stats/<provider>')`. Defaults to `require ('keuss/stats/mem')`.
@@ -28,23 +30,28 @@ where `opts` is an object containing initialization options. Common properties t
   * `queue`: deadletter queue name.
 
 The following are backend-dependent values:
+
 * backends *mongo*, *pl-mongo* and *ps-mongo*.
-   * `url`: mongodb url to use, defaults to `mongodb://localhost:27017/keuss`.
+  * `url`: mongodb url to use, defaults to `mongodb://localhost:27017/keuss`.
 * backends *redis-list* and *redis-oq*.
   * `redis`: data to create a redis connection to the Redis acting as backend, see below.
 * backend *ps-mongo*.
   * `ttl`: time to keep consumed elements in the collection after being removed. Defauls to 3600 secs.
 
 ### MongoDB defaults
+
 On MongoDB-based backends, `signaller` and `stats` defaults to:
+
 * `signaller`: uses `mongo-capped`, using the same mongodb url than the backend, but postfixing the db with `_signal`.
 * `stats`: uses `mongo-capped`, using the same mongodb url than the backend, but postfixing the db with `_stats`.
 This alows cleaner and more concise initialization, using a sane default.
 
 ### Dead Letter
+
 The concept of *deadletter* is very common on queue middlewares: in case reserve/commit/rollback is used to consume, a maximum number of fails (reserve-rollback) can be set on each element; if an element sees more rollbacks than allowed, the element is moved to an special queue (dead letter queue) for later, offline inspection.
 
 By default, keuss uses no deadletter queue; it can be activated by passing a `deadletter` object at the time of factory creation, in the options:
+
 ```javascript
 var factory_opts = {
   url: 'mongodb://localhost/qeus',
@@ -57,7 +64,9 @@ var factory_opts = {
 MQ(factory_opts, (err, factory) => {
   ...
 ```
+
 This object must not be empty, and can contain the following keys:
+
 * `max_ko`: maximum number of rollbacks per element allowed. The next rollback will cause the element to be moved to the deadletter queue. Defaults to 0, which means `infinite`.
 * `queue`: queue name of the deadletter queue, defaults to `__deadletter__`.
 
@@ -66,10 +75,12 @@ All storage backends support deadletter. In `ps-mongo` the move-to-deadletter (a
 :::
 
 ## `queue`: Queue creation
+
 ```javascript
 // factory has been initialized
 var q = factory.queue (<name>, <options>);
 ```
+
 Where:
 
 * `name`: string to be used as queue name. Queues with the same name are in fact the same queue if they're backed in the same factory type using the same initialization data (mongodb url or redis conn-data).
@@ -83,7 +94,9 @@ Where:
     * `opts`: options for the stats factory (see below).
 
 ## `close`: Factory close
+
 ```javascript
 factory.close (err => {...});
 ```
+
 Frees up resources on the factory. Queues created with the factory will become unusable afterwards. See ['Shutdown process'](../usage/shutdown.md) for more info.

--- a/docusaurus/docs/api/queue.md
+++ b/docusaurus/docs/api/queue.md
@@ -5,57 +5,71 @@ sidebar_label: Queue
 ---
 
 ### `stats`: Queue stats
+
 ```javascript
 q.stats ((err, res) => {
   ...
 })
 ```
+
 * `res` contains usage statistics (elements inserted, elements extracted, paused status).
 
 ### `name`: Queue name
+
 ```javascript
 var qname = q.name ()
 ```
 
 ### `type`: Queue type
+
 ```javascript
 var qtype = q.type ()
 ```
+
 Returns a string with the type of the queue (the type of backend which was used to create it).
 
 ### `size`: Queue occupation
+
 ```javascript
 q.size ((err, res) => {
   ...
 })
 ```
+
 Returns the number of elements in the queue that are already elligible (that is, excluding scheduled elements with a schedule time in the future).
 
 ### `totalSize`: Total queue occupation
+
 ```javascript
 q.totalSize ((err, res) => {
   ...
 })
 ```
+
 Returns the number of elements in the queue (that is, including scheduled elements with a schedule time in the future).
 
 ### `schedSize`: Size of Scheduled
+
 ```javascript
 q.schedSize ((err, res) => {
   ...
 })
 ```
+
 Returns the number of scheduled elements in the queue (that is, those with a schedule time in the future). Returns 0 if the queue does not support scheduling.
 
 ### `resvSize`: Reserved elements size
+
 ```javascript
 q.resvSize ((err, res) => {
   ...
 })
 ```
+
 Returns the number of reserved elements in the queue. Returns `null` if the queue does not support reserve.
 
 ### `pause` / `paused`: Pause/Resume
+
 ```javascript
 // pauses the queue
 q.pause (true)
@@ -68,6 +82,7 @@ q.paused ((err, is_paused) => {
   ...
 })
 ```
+
 Pauses/Resumes all consumers on this queue (calls to `pop()`). Producers are not afected (calls to `push()`).
 
 The pause/resume condition is propagated via the signallers, so this affects all consumers, not only those local to the process, if a redis-pubsub or mongo-capped signaller is used.
@@ -75,22 +90,27 @@ The pause/resume condition is propagated via the signallers, so this affects all
 Also, the paused condition is stored as stats, so any new call to `pop()` will honor it.
 
 ### `next_t`: Time of schedule of next message
+
 ```javascript
 q.next_t ((err, res) => {
   ...
 })
 ```
+
 Returns a `Date`, or `null` if queue is empty. Queues with no support for schedule/delay always return `null 
 
 ### `push`: Add element to queue
+
 ```javascript
 q.push (payload, [opts,] (err, res) => {
   ...
 })
 ```
+
 Adds payload to the queue and calls passed callback upon completion. Callback's *res* will contain the id assigned to the inserted element, if the backup provides one.
 
 Possible opts:
+
 * `mature`: unix timestamp where the element would be elligible for extraction. It is guaranteed that the element won't be extracted before this time.
 * `delay`: delay in seconds to calculate the mature timestamp, if mature is not provided. For example, a delay=120 guarantees the element won't be extracted until 120 secs have elapsed *at least*.
 * `tries`: value to initialize the retry counter, defaults to 0 (still no retries).
@@ -98,21 +118,26 @@ Possible opts:
 :::note
 **mature** and **delay** have no effect if the backend does not support delay/schedule.
 :::
+
 ### `pop`: Get element from queue
+
 ```javascript
 var tr = q.pop (cid, [opts,] (err, res) => {
   ...
 })
 ```
+
 Obtains an element from the queue. Callback is called with the element obtained if any, or if an error happened. If defined, the operation will wait for `opts.timeout` seconds for an element to appear in the queue before bailing out (with both `err` and `res` being null). However, it immediately returns an id that can be used to cancel the operation at anytime.
 
 `*cid*` is an string that identifies the consumer entity; it is used only for debugging purposes.
 
 Possible opts:
+
 * **timeout**: milliseconds to wait for an elligible element to appear in the queue to be returned. If not defined it will wait forever
 * **reserve**: if `true` the element is only reserved, not completely returned. This means either *ok* or *ko* operations are needed upon the obtained element once processed, otherwise the element will be rolled back (and made available again) at some point in the future (this is only available on backends capable of reserve/commit).
 
 ### `cancel`: Cancel a pending Pop
+
 ```javascript
 var tr = q.pop (cid, opts, (err, res) => {...});
 .
@@ -120,19 +145,23 @@ var tr = q.pop (cid, opts, (err, res) => {...});
 .
 q.cancel (tr);
 ```
+
 Cancels a pending `pop` operation, identified by the value returned by `pop()`
 
 If no `tr` param is passed, or it is `null`, all pending `pop` operations on the queue are cancelled. Cancelled `pop` operations will get `'cancel'` (a string) in the `error` parameter value of the callback.
 
 ### `ok`: Commit a reserved element
+
 ```javascript
 q.ok (id, (err, res) => {
   ...
 })
 ```
+
 Commits a reserved element by its id (the id would be assigned to `res._id` on the `res` param of `pop()` operation). This effectively erases the element from the queue.
 
 Alternatively, you can pass the entire `res` object from the `pop()` operation:
+
 ```javascript
 var tr = q.pop ('my-consumer-id', {reserve: true}, (err, res) => {
   // do something with res
@@ -146,14 +175,17 @@ var tr = q.pop ('my-consumer-id', {reserve: true}, (err, res) => {
 ```
 
 ### `ko`: Roll back a reserved element
+
 ```javascript
 q.ko (id, next_t, (err, res) => {
   ...
 })
 ```
+
 Rolls back a reserved element by its id (the id would be at `res._id` on the `res` param of `pop()` operation). This effectively makes the element available again at the queue, marking it to be mature at `next_t` (`next_t` being a millsec-unixtime). If no `next_t` is specified or a `null` is passed, `now()` is assumed.
 
 As with `ok()`, you can use the entire `res` object instead:
+
 ```javascript
 var tr = q.pop ('my-consumer-id', {reserve: true}, (err, res) => {
   // do something with res
@@ -168,16 +200,19 @@ var tr = q.pop ('my-consumer-id', {reserve: true}, (err, res) => {
   })
 });
 ```
+
 :::important
 You must pass the entire `res` object for the [deadletter](../api/factory#dead-letter) feature to work; even if activated at the factory, `ko()` will not honor deadletter if you only pass the `res._id` as `id`.
 :::
 
 ### `drain`: Drain queue
+
 ```javascript
 q.drain (err => {
   ...
 })
 ```
+
 Drains a queue. This is a needed operation when a backend does read-ahead upon a `pop()`, or buffers `push()` operations for later; in this case, you may want to be sure that all extra elemens read are actually popped, and all pending pushes are committed.
 
 :::warning

--- a/docusaurus/docs/api/signal.md
+++ b/docusaurus/docs/api/signal.md
@@ -4,6 +4,7 @@ title: Signaller API
 sidebar_label: Signaller
 ---
 ## Signaler factory
+
 Signaller factory is passed to queues either in queue creation or in backend init, inside *opts.signaller*. Note that the result for the *new* operation is indeed the factory; the result of the `require` is therefore a *metafactory*.
 
 ```javascript

--- a/docusaurus/docs/api/stats.md
+++ b/docusaurus/docs/api/stats.md
@@ -5,6 +5,7 @@ sidebar_label: Stats
 ---
 
 ## Stats factories
+
 Stats factories are passed to queues either in queue creation or in backend init, inside *opts.signaller*. Note that the result of the `new` operation is indeed the factory; the result of the `require` is therefore a *metafactory*
 
 ```javascript
@@ -32,4 +33,5 @@ MQ (f_opts, (err, factory) => {
   // queues created by factory here will use a redis-backed stats, hosted at redis at localhost, db 6
 })
 ```
+
 Stats objects, as of now, store the number of elements inserted and the number of elements extracted; they are created behind the scenes and tied to queue instances, and the stats-related interface is in fact part of the queues' interface.

--- a/docusaurus/docs/changelog.md
+++ b/docusaurus/docs/changelog.md
@@ -28,5 +28,4 @@ sidebar_label: Changelog
 * v1.5.3:
   * use mongodb driver v3.2 (was v2.2)
 * v1.5.2
-  *  added bucket-based backends: 2 backends using buckets/buffering on top of mongodb
-
+  * added bucket-based backends: 2 backends using buckets/buffering on top of mongodb

--- a/docusaurus/docs/concepts.md
+++ b/docusaurus/docs/concepts.md
@@ -5,35 +5,42 @@ sidebar_label: Concepts
 ---
 
 ## Queue
-a **Queue** is more of an interface, a definition of what it can do. Keuss queues are capable of:
+
+A **Queue** is more of an interface, a definition of what it can do. Keuss queues are capable of:
+
 * Insert one element.
-* Schedule an element: insert one element with a not-before datetime.
+* Schedule an element: insert one element with a not-before datetime; this means, the element will be affectively inserted in the queue, but any operation on the queue ofter that will not take that element into account before the not-before datetime.
 * Get an element, and block for some specified time if no element is available.
 * Reserve an element, and block for some specified time if no element is available.
 * Commit (remove) or rollback (return back) a previously reserved element.
-* Get element count.
+* Get element count (it will not include the elements scheduled in the future).
 * Get element count whose not-before datetime is in the future (scheduled elements).
 * Get usage stats: elements inserted, elements extracted.
 
 *Element* here translates to any js object. Internally, it's usually managed as json.
 
 ## Bucket
+
 The initial idea for Keuss Queues, transtated the elements inserted in the queue into rows of the backed storage. This makes it easy to inspect the elements values directly in the backend, which is pretty useful when you need to debug things up. Buckets came later, as a way to pack more than one message into a single row of the backend to gain performance. See [Bucked-based backends](usage/buckets).
 
 ## Pipeline
+
 A **[pipeline](usage/pipelines/about)** is an enhanced queue that provides an extra operation: pass an element to another queue **atomically**. In an scenario where processors are linked with queues, it is usually a good feature to allow the *'commit element in incoming queue, insert element in the next queue'* to be atomic. This removes chances for race conditions, or message losses.
 
 The pipeline concept is, indeed, an extension of the reserve-commit model; it is so far implemented only atop mongodb, and it is anyway considered as a 'low-level' feature, best used by means of specialized classes to encapsulate the aforementioned processors.
 
 ## Processor
-A **processor** is an object tied to one or more queues, that controls the flow of messages between them. They are used mainly to define **pipelines**. Currently there are 4 specialized classes of processors defined:
+
+A **processor** is an object tied to one or more queues, that controls the flow of messages between them. They are used mainly to define [**pipelines**](usage/pipelines/about). Currently there are 4 specialized classes of processors defined:
+
 * [BaseLink](usage/pipelines/processors#baselink): This is really more of a base definition for the rest of the specialized processors.
 * [DirectLink](usage/pipelines/processors#directlink) (one queue to another).
 * [ChoiceLink](usage/pipelines/processors#choicelink) (one queue to one or more queues).
 * [Sink](usage/pipelines/processors#sink) (endpoint, one queue to none).
 
 ## Storage
-**Storage** or **Backend** provides almost-complete queue primitives, fully functional and already usable as is. Keuss comes with 7 backends, with various levels of features and performance:
+
+The **Storage** or **Backend** provides almost-complete queue primitives, fully functional and already usable as is. Keuss comes with 7 backends, with various levels of features and performance:
 
 * *`mongo`*, a mongodb-based backend that provides the full set of queue features, still with decent performance.
 * *`redis-oq`*, backed using an ordered queue on top of redis (made in turn with a sorted set, a hash and some lua). Provides all queue features including reserve-commit-rollback. Noticeable faster than mongodb.
@@ -58,12 +65,15 @@ bucket-mongo      | - | - | - | - | +++++
 bucket-mongo-safe | x | x | - | - | +++++
 
 ## Signaller
+
 **Signaller** provides a bus interconnecting all keuss clients, so events can be shared. Keuss provides 3 signallers:
+
 * *`local`* : provides in-proccess messaging, useful only for simple cases or testing
 * *`redis-pubsub`*: uses the pubsub subsystem provided by redis
 * *`mongo-capped`*: uses pubsub on top of a mongodb capped collection, using [@nodebb/mubsub](https://www.npmjs.com/package/@nodebb/mubsub)
 
 So far, the only events published by keuss are:
+
 * *element inserted in queue X*, which allows other clients waiting for elements to be available to wake up and retry. A client will not fire an event if
   another one of the same type (same client, same queue) was already fired less than 50ms ago.
 * *queue X paused/resumed*.
@@ -73,12 +83,15 @@ The use of a signaller provider different from `local` allows the formation of a
 queue *on every machine* will be awaken when an insertion happens *on any machine*)
 
 ## Stats
+
 **Stats** provides counters and metrics on queues, shared among keuss clients. The supported stats are:
+
 * Elements put
 * Elements got
 * Paused status
 
 Three options are provided to store the stats:
+
 * *`mem`*: very simple in-process, memory based.
 * *`redis`*: backed by redis hashes. Modifications are buffered in memory and flushed every 100ms.
 * *`mongo`*: backed by mongodb using one object per queue inside a single collection. Modifications are buffered in memory and flushed every 100ms.
@@ -91,6 +104,7 @@ needed to ensure this is also stored alongside the actual stats). Keuss does not
 top of this
 
 ## How all fits together
+
 * *`Queues`*, or rather clients to individual queues, are created using a *backend* as factory.
 * *`Backends`* need to be initialized before being used. Exact initialization details depend on each backend.
 * When creating a *`queue`*, a *`signaller`* and a *`stats`* are assigned to it. The actual class/type to be used can be specified at the queue's creation moment, or at the backend initialization moment. By default *`local`* and *`mem`*, respectively, are used for redis-based backends; for mongodb-based backends, *`mongo-capped`* and *`mongo`* are used intead as defaults

--- a/docusaurus/docs/examples.md
+++ b/docusaurus/docs/examples.md
@@ -5,5 +5,6 @@ sidebar_label: Examples
 ---
 
 A set of funcioning examples can be found inside the *examples* directory:
+
 * [webhooks](https://github.com/pepmartinez/keuss/tree/master/examples/webhooks): A small but functionally complete webhook dispatcher sporting retries, reserve-commit, persistence and deadletter
 * [snippets](https://github.com/pepmartinez/keuss/tree/master/examples/snippets): A set of assorted code snippets for various tasks

--- a/docusaurus/docs/quickstart.md
+++ b/docusaurus/docs/quickstart.md
@@ -5,12 +5,15 @@ sidebar_label: Quickstart
 ---
 
 ## Package Install
+
 `keuss` is installed in the regular way for any npm package:
 
 ```bash
 npm install keuss
 ```
-# Basic usage (with regular MongoDB backend)
+
+## Basic usage (with regular MongoDB backend)
+
 Here's a minimal example of how keuss works. [async](https://www.npmjs.com/package/async) is used to implement asynchronous flows in a much readable manner
 
 ```javascript
@@ -47,15 +50,19 @@ MQ ({
   });
 });
 ```
+
 This small test creates a queue named `test_queue` backed by mongodb in the mongoDB collection at `mongodb://localhost/keuss_test`. Then, a single element is first inserted in the queue, then read from it and printed
 
 ## Backend interchangeability
+
 This example works with any available definition of `MQ`; you just need to specify the chosen backend. For example, to use the `redis-list` backend:
+
 ```js
 const MQ = require ('keuss/backends/redis-list');
 ```
 
-# reserve-commit-rollback
+## reserve-commit-rollback
+
 ```javascript
 const async = require ('async');
 const MQ =    require ('keuss/backends/mongo');
@@ -87,6 +94,7 @@ MQ ({
   });
 });
 ```
+
 1. An element is inserted.
 2. An element is reserved. It reserves the element previously inserted, and returns it.
 3. This should print the element reserved.
@@ -96,12 +104,15 @@ MQ ({
 7. The element is committed and thus removed from the queue.
 
 ## Backend interchangeability
+
 This example works with any definition of `MQ` that supports reserve/commit (that is, any except `redis-list` and `bucket-mongo`); you just need to specify the chosen backend. For example, to use the `bucket-mongo-safe` backend:
+
 ```js
 const MQ = require ('keuss/backends/bucket-mongo-safe');
 ```
 
 ## Full producer and consumer loops
+
 This is a more convoluted example: a set of producers inserting messages, and another set of consumers consumig them, all in parallel. The queue stats (elements pushed, elements popped) are shown every second.
 
 Try and change the uncommented `const MQ = require('keuss/backends/...');`  to see the performance differences between backends.

--- a/docusaurus/docs/usage/buckets.md
+++ b/docusaurus/docs/usage/buckets.md
@@ -11,7 +11,9 @@ Starting with v1.5.2 keuss includes 2 backends that do not share this limitation
 Two bucked-based backends were added, both based on mongodb: [bucket-mongo](#bucket-mongo) and [bucket-mongo-safe](#bucket-mongo-safe). Both are usable, but there is little gain on using fhe first over the second: `bucket-mongo` was used as a prototyping area, and although perfectly usable, it turned out `bucket-mongo-safe` is better in almost every aspect: it provides better guarantees and more features, at about the same performance.
 
 ### bucket-mongo-safe
+
 In addition to the general options, the factory accepts the following extra options:
+
 * `bucket_max_size`: maximum number of elements in a bucket, defaults to 1024
 * `bucket_max_wait`: milliseconds to wait before flushing a push bucket: pushes are buffered in a push bucket, which are flushed when they're full (reach `bucket_max_size` elements). If this amount of millisecs go by and the push bucket is not yet full, it is flushed as is. Defaults to 500.
 * `reserve_delay`: number of seconds a bucket keeps its 'reserved' status when read from mongodb. Defaults to 30.
@@ -21,6 +23,7 @@ In addition to the general options, the factory accepts the following extra opti
 * `state_flush_period`: flush intermediate state changes in each active read bucked every this amount of millisecs
 
 Bucket-mongo-safe works by packing many payloads in a single mongodb object:
+
 * At `push()` time, objects are buffered in memory and pushed (inserted) only when bucket_max_size has been reached or when a bucket has been getting filled for longer than bucket_max_wait millisecs.
 * At `pop/reserve` time full objects are read into mem, and then individual payloads returned from there. Both commits and pops are just marked in memory and then flushed every state_flush_period millisecs, or when the bucked is exhausted.
 * Buckets remain unmodified since they are created in terms of the payloads they contain: a `pop()` or `ko/ok` would only mark payloads inside buckets as read/not-anymore-available, but buckets are never splitted nor merged.
@@ -34,6 +37,7 @@ Scheduling on `bucket-mongo-safe` is perfectly possible, but with a twist: the e
 :::
 
 ### bucket-mongo
+
 This is a simpler version of buckets-on-mongodb, and for all purposes `bucket-mongo-safe` should be preferred; it does not provide reserve, nor schedule. It is however a tad faster and lighter on I/O.
 
 It is provided only for historical and educational purposes.

--- a/docusaurus/docs/usage/pipelines/about.md
+++ b/docusaurus/docs/usage/pipelines/about.md
@@ -10,7 +10,6 @@ Keuss pipelines are build upon Keuss Queues with *pipeline* capacity, which mean
 
 Queues are linked together with processing units named *Processors*, which glue together a source queue with zero or more destination queues. Each processor encapsulates a loop that could be described -in its simplest form- as follows:
 
-
 ```javascript
 forever do
   src_queue.reserve () -> element    # reserve an element from entry queue
@@ -40,6 +39,7 @@ end
 * The exact semantics of `move_to_next_queue()` vary depending on the specific type of Processor chosen
 
 ## Real, simple example
+
 Here is the simplest possible example: 2 queues connected with a very simple processor. Elements in the source queue are taken, a `passed: true` is added to them and moved to the next queue:
 
 ```javascript
@@ -86,6 +86,7 @@ MQ (factory_opts, (err, factory) => {
 just run this example and you'll see 111 elements being inserted at q1, being processed at the pdl processor, and then popped from q2
 
 ## Pipeline-aware Queues
+
 As stated before only one Keuss Queue backed -`pl-mongo`- is compatible with pipelines. Those are the pipeline-related options available at the backend:
 
 * `pipeline`: specifies the pipeline name for this queue. Only queues within the same pipeline (that is, same mongodb url and same pipeline name) can actually work together in a pipeline. Defaults to `default`
@@ -111,6 +112,7 @@ pl_step (id, next_queue, opts, callback)
   * `tries`: number of tries for the item, to be used when inserted into next_queue. Defaults to `0`
   * `payload`: if specified, use this as item's payload when moving to next_queue. This totally substitutes the previous payload
   * `update`: Optional object containing [mongodb update operations](https://docs.mongodb.com/manual/reference/operator/update/). Those are mapped to be applied to the message's `payload`. For example, in the example above:
+
     ```javascript
     done (null, {
       update: {
@@ -118,6 +120,7 @@ pl_step (id, next_queue, opts, callback)
       }
     });
     ```
+
     the '`update` parameter of the second argument to `done()` is passed internally to `pl_step()` as `opts.update`: this would cause the message's `payload.passed` to be set to `true` even if there's no explicit mention of `payload`
 
 The whole `pl_step()` operation is guaranteed to be atomic; this includes applying of `opts.payload` or `opts.update` if present

--- a/docusaurus/docs/usage/pipelines/building.md
+++ b/docusaurus/docs/usage/pipelines/building.md
@@ -5,12 +5,15 @@ sidebar_label: Building
 ---
 
 Pipelines can be built in 3 ways:
+
 * By directly creating queues and processors, and bonding them together. This is rather low-level and is not the recommended way
 * By using a `PipelineBuilder`. This object provides a fluent API that's convenient and very simple. This is the recommended way to created pipelines in code
 * By using the method `pipelineFromRecipe` offered by the Queues Factories supporting pipelining. This allows a whole pipeline to be defined in a set of strings and therefore in external files; this makes pipelies portable, reproductible and totally cluster-ready
 
 ## Direct Pipeline Creation
+
 This is a quite simple approach: you create the queues, then you create the Processors that would glue them. Processors take i theit constructors the queues they use, so it's rather straightforward:
+
 ```javascript
 const MQ =  require ('../../../backends/pl-mongo');
 const DCT = require ('../../../Pipeline/DirectLink');
@@ -67,9 +70,11 @@ MQ (factory_opts, (err, factory) => {
 });
 
 ```
+
 See [Processors](processors.md) for all the available options and features (such as processing functions and error management)
 
 ## Creation with a `PipelineBuilder`
+
 `PipelineBuilder` provides a simpler way to create pipelines using a fluent api. Builders are obtained through `factory.builder()` and offers the following methods:
 
 * `pipeline(name)`: initializes a pipeline, passing a name to it. Must be called before any other method, and can be called only once
@@ -81,11 +86,14 @@ See [Processors](processors.md) for all the available options and features (such
 * `done(err, pipeline)`: finished the pipeline creation. No other calls can be done to the builder afterwards. In case of error, the error will be passed in `err`; if all went well `err` will be `null` and the newly created pipeline, an object of type `Pipeline`, will be passed in the `pipeline`; all further interactions with the pipeline will happen through this object
 
 ### Pipepine object
+
 The new Pipeline object exports the following methods:
+
 * `start()`: starts the pipeline (simply calls `start()` on all processors)
 * `stop()`: stops the pipeline (simply calls `stop()` on all processors)
 
 Here's a simplified example (for a complete, working example see [here](https://github.com/pepmartinez/keuss/tree/master/examples/pipelines/builder)):
+
 ```javascript
 MQ (factory_opts, (err, factory) => {
   if (err) return console.error (err);
@@ -115,6 +123,7 @@ MQ (factory_opts, (err, factory) => {
 ```
 
 ## Creation with `Factory.pipelineFromRecipe`
+
 `Factory.pipelineFromRecipe` provides a way to define pipelines entirely from strings, including queue, processors, the functions
 to be used as process functions and all the code used on those functions. In this way a full, self-contained pipeline can be specified
 in a file or set of files

--- a/docusaurus/docs/usage/pipelines/processors.md
+++ b/docusaurus/docs/usage/pipelines/processors.md
@@ -7,13 +7,17 @@ sidebar_label: Processors
 A small hierarchy of processors is provided with Pipelines:
 
 ## BaseLink
+
 Common base for all Processors, provides all the functionality common to all. It can not be used directly
 
 ### Creation
+
 ```javascript
 const bl = new BaseLink (src_q, opts)
 ```
+
 Although not intended to be instantiated, this serves as common initialization to all Processors
+
 * `src_q` must be a pipelined queue
 * `opts` can contain:
   * `retry_factor_t, retry_base_t`: they control the delay imposed to an element when it is rolled back. The formula is
@@ -25,17 +29,19 @@ Although not intended to be instantiated, this serves as common initialization t
   * `delay`: delay in seconds to calculate `mature`, if `mature` is not specified
 
 ### Methods
+
 * `src()`: returns src queue
 * `name()`: returns Processor name
 * `on_data(fn)`: specifies the process function to be applied to each element
 * `start(fn)`: starts the processor. Optionally, a process function can be passed; if not passed the process function must have been previously specified using `on_data()`
 * `stop()`: stops the Processor
 
-
 ### Process Function
+
 The function passed into `on_data()` or `start()` provides the processor logic; this function is referred to as *processor function*. This function is called on each step of the Processor loop with the reserved item, and it is expected to calls its callback once done with the item. The way the function calls the callback determines what happens with the item afterwards
 
 The function looks like this:
+
 ```javascript
 function (item, cb) {
   ...
@@ -47,13 +53,14 @@ The `item` is received exactly as it comes as result of a (successful) `reserve(
 ```javascript
   cb (err, res);
 ```
+
 where:
 
 * if `err` is not nil
   * if `err.drop` is exactly `true` the item is committed in the src queue and therefore dropped from the pipeline
   * else the item is rolled back in the src queue, using the processor's `retry_factor_t` and `retry_base_t` to calculate the retry delay. If the queue was created with deadletter support, the item would be moved to the deadletter queue if it has reached its maximum number of rollbacks; in such case, the movement into deadletter is also atomic
 * else (if `err` is nill)
-  *  if (`res.drop` is exactly `true` the item is committed in the src queue and therefore dropped from the pipeline
+  * if (`res.drop` is exactly `true` the item is committed in the src queue and therefore dropped from the pipeline
   * else the item is passed to the text queue in the pipeline (by means of `pl_next()`)
     * if `res.mature` or `res.delay` exist (or they were specified at the processor's creation) they are used to calculate the delay/mature of the element in the destination queue
     * if `res.payload` exists it is used to replace the item's payload entirely
@@ -62,12 +69,15 @@ where:
   All those operations happen in an atomic way
 
 #### Semantic `this` in process function
+
 The function is bound to the processor, so the function can access and use processor's primitives. For example, it can insert copies of the item, or new items, in any of the source or destination queues
 
 In order to use this functionality the process function can not be declared as an 'arrow' function, since those can not be bound. Use the classic `function xxxx (item, cb) {...}` if you intend to access the underlying Processor
 
 ### Events
+
 BaseLink inherits from `EventEmitter` and publishes the following events:
+
 * `error`: an error happened in the internal loop. It comes with one parameter, an object with the following fields:
   * `on`: exact type of error:
     * `src-queue-pop`: error while reserving an element on the src queue
@@ -80,31 +90,40 @@ BaseLink inherits from `EventEmitter` and publishes the following events:
   * `opts`: (only present in `next-queue`) options passed internally to `pl_step()`
 
 ## DirectLink
+
 Processor that connects the source queue to exactly one destination queue:
+
 ```
  src-queue --> DirectLink --> dst-queue
 ```
 
 ### Creation
+
 ```javascript
 const PDL = require ('keuss/Pipeline/DirectLink');
 const bl = new PDL (src_q, dst_q, opts);
 ```
 
 In addition to `BaseLink`:
+
 * `dst_q` must be a pipelined queue; also, both `src_q` and `dst_q` must be of the same type and must belong to the same pipeline
 
 ### Methods
+
 In addition to those of `BaseLink`
+
 * `dst()`: returns destination queue
 
 ### Process Function
+
 In the case of successful processing (i.e.: no `err` in the callback invocation) the item is atomically moved to the `dst` queue.
 
 No other semantics are added to the process function.
 
 ## ChoiceLink
+
 Processor that connects the source queue to an array of queues; after processing, each item would be moved to exactly one of those queues:
+
 ```
                             |--> dst-queue-0
                             |--> dst-queue-1
@@ -114,35 +133,44 @@ Processor that connects the source queue to an array of queues; after processing
 ```
 
 ### Creation
+
 ```javascript
 const PCL = require ('keuss/Pipeline/ChoiceLink');
 const cl = new PCL (src_q, array_of_dst_queues, opts);
 ```
 
 In addition to `BaseLink`:
+
 * `array_of_dst_queues` must be an array of pipelined queues; each one must be of the same type and must belong to the same pipeline than `src_q`
 
 ### Methods
-In addition to those of `BaseLink`
+
+In addition to those of `BaseLink`:
+
 * `dst_by_idx(idx)`: returns destination queue from the array, selected by array index (integer)
 * `dst_by_name(name)`: returns destination queue from the array, selected by queue name (string)
 * `dst_dimension ()`: returns number of possible destination queues
 * `dst_names ()`: returns an array with the names of all dst queues
 
 ### Process Function
+
 ChoiceLink expects an `res.dst` in the callback invocation, which must fullfill one of those conditions:
+
 * be an integer and resolve to a valid element when applied as index to the array of destination queues
 * be a string and correspond to the name of one of the destination queues
 
 The element will be moved atomically to the specified destination queue upon successful processing (i.e.: no `err`in the callback invocation)
 
 ## Sink
+
 Processor that connects the source queue to exactly zero destination queue. That is, a termination point: successfully processed elements are always removed from the pipeline
+
 ```
  src-queue --> Sink
 ```
 
 ### Creation
+
 ```javascript
 const PS = require ('keuss/Pipeline/Sink');
 const bl = new PS (src_q, opts);
@@ -151,7 +179,9 @@ const bl = new PS (src_q, opts);
 No extra parameters are expected in addition to those of `BaseLink`
 
 ### Methods
+
 No extra methods are provided in addition to those of `BaseLink`
 
 ### Process Function
+
 In the case of successful processing (i.e.: no `err` in the callback invocation) the item is removed from the pipeline, exactly as if `res.drop` were specified. Actually, `res` is totally ignored

--- a/docusaurus/docs/usage/putting-all-together.md
+++ b/docusaurus/docs/usage/putting-all-together.md
@@ -5,12 +5,15 @@ sidebar_label: Putting all together
 ---
 
 ## Factory initialization
+
 First, choose a factory, also known as backend:
+
 ```javascript
 const MQ = require ('../../backends/mongo');
 ```
 
 Then, simply execute the backend, passing the config, to obtain a working factory:
+
 ```javascript
 MQ ({
   url: 'mongodb://localhost/keuss_test'
@@ -21,22 +24,29 @@ MQ ({
 
 }
 ```
+
 You can create and use as many factories as desided, from the same or many backends
 
 ## Queue creation
+
 You use the factory to create queues:
+
 ```javascript
 const q1 = factory.queue ('test_queue_1', {});
 const q2 = factory.queue ('test_queue_2', {});
 ```
+
 A queue can be created more than once with the same name, inside the same factory (this is a common procedure when consumer and producer are separated). The effect would be virtually the same as sharing the queue:
+
 ```javascript
 const q_consumer = factory.queue ('test_queue', {});
 const q_producer = factory.queue ('test_queue', {});
 ```
 
 ## Put elements in queue (push)
+
 putting elements in a queue is simple enough:
+
 ```javascript
 const elem = {
   elem: 1,
@@ -53,6 +63,7 @@ q1.push (elem, (err, res) => {
 ```
 
 ## Get elements from queue (pop)
+
 The easiest way to get elements from a queue is with a simple pop(). This would block until an element is ready, it would remove it from the queue and return it.
 
 This way of working is often referred to as *at-most-once* since it guarantees that each element in the queue will be processed no more than one time (it would be zero times, if something happens after `pop()` ands but before the element is actually managed)
@@ -76,7 +87,9 @@ q1.pop (consumer_label, (err, res) => {
 ```
 
 ## Reserve-commit-rollback
+
 A safer way to consume from a queue is using reserve: elements are reserved, processed and only then committed (and removed from the queue). A reserved element can also be rolled back (returned to queue) if the processing failed and the element needs to be reprocessed in the future; also, any reserved element will auto-rollback after some tiem elapsed, if neither commit nor rollback is done. This is known as *at-least-once* cause it guarantees all elements wold be processed at least once
+
 ```javascript
 const consumer_label = 'consumer-1';
 q1.pop (consumer_label, {reserve: true}, (err, elem) => {
@@ -102,10 +115,13 @@ q1.pop (consumer_label, {reserve: true}, (err, elem) => {
 ```
 
 ## Termination
+
 Once all is done, you can free all the resources associated to the factory by closing it:
+
 ```javascript
 factory.close (err => {
   // factory is now closed and cannot be used anymore
 });
 ```
+
 Once a factory is closed it cannot be used, *and all the queues created through it will becomes unusable too*

--- a/docusaurus/docs/usage/redis-conns.md
+++ b/docusaurus/docs/usage/redis-conns.md
@@ -5,6 +5,7 @@ sidebar_label: Redis Connections
 ---
 
 Keuss relies on [ioredis](https://www.npmjs.com/package/ioredis) for connecting to redis. Anytime a redis connection is needed, keuss will create it from the opts object passed:
+
 * If `opts` is a function, it is executed. It is expected to return a redis connection
 * If it's an object and contains a `Redis` field, this field is used to create a new [ioredis Redis object](https://github.com/luin/ioredis), as in *return new Redis (opts.Redis)*
 * if it's an object and contains a `Cluster` field, this field is used to create a new [ioredis Redis.Cluster](https://redis.io/topics/cluster-spec) object, as in *return new Redis.Cluster (opts.Cluster)*
@@ -13,7 +14,9 @@ Keuss relies on [ioredis](https://www.npmjs.com/package/ioredis) for connecting 
 This apparent complexity is required since redis connections are inherently created in a different way for standalone, sentinel and cluster servers
 
 ## Examples:
+
 * Default options:
+
   ```javascript
   var MQ = require ('keuss/backends/redis-list');
   var factory_opts = {};
@@ -24,6 +27,7 @@ This apparent complexity is required since redis connections are inherently crea
   ```
 
 * Specific redis params for ioredis Redis client:
+
   ```javascript
   var MQ = require ('keuss/backends/redis-list');
   var factory_opts = {
@@ -44,6 +48,7 @@ This apparent complexity is required since redis connections are inherently crea
   ```
 
 * Using a factory function:
+
   ```javascript
   var MQ = require ('keuss/backends/redis-list');
   var Redis = require ('ioredis');


### PR DESCRIPTION
No really important changes, just clarify one concept and some markdown whitespace cleanse.